### PR TITLE
GH-5327 RDF 1.2 JSON datatype and directed language strings

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Literal.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Literal.java
@@ -41,6 +41,36 @@ import org.eclipse.rdf4j.model.base.CoreDatatype;
  * @see <a href="https://www.w3.org/TR/xmlschema11-2">XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes</a>
  */
 public interface Literal extends Value {
+	String LTR_SUFFIX = "--ltr";
+	String RTL_SUFFIX = "--rtl";
+	String BASE_DIR_SEPARATOR = "--";
+
+	enum BaseDirection {
+		NONE(""),
+		LTR(LTR_SUFFIX),
+		RTL(RTL_SUFFIX);
+
+		private final String suffix;
+
+		BaseDirection(final String suffix) {
+			this.suffix = suffix;
+		}
+
+		@Override
+		public String toString() {
+			return suffix;
+		}
+
+		public static BaseDirection fromString(final String dir) {
+			if (dir == null || dir.isEmpty())
+				return NONE;
+			if (dir.equals(LTR_SUFFIX))
+				return LTR;
+			if (dir.equals(RTL_SUFFIX))
+				return RTL;
+			throw new IllegalArgumentException("Unknown BaseDirection: " + dir);
+		}
+	}
 
 	@Override
 	default boolean isLiteral() {
@@ -60,6 +90,10 @@ public interface Literal extends Value {
 	 * @return The language tag for this literal, or {@link Optional#empty()} if it doesn't have one.
 	 */
 	Optional<String> getLanguage();
+
+	default BaseDirection getBaseDirection() {
+		return BaseDirection.NONE;
+	}
 
 	/**
 	 * Gets the datatype for this literal.

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -87,6 +87,18 @@ public interface ValueFactory {
 	Literal createLiteral(String label, String language);
 
 	/**
+	 * Creates a new literal with the supplied label and language attribute. The return value of
+	 * {@link Literal#getDatatype()} for the returned object must be
+	 * <a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#langString">{@code rdf:langString}</a>.
+	 *
+	 * @param label         The literal's label, must not be <var>null</var>.
+	 * @param language      The literal's language attribute, must not be <var>null</var>.
+	 * @param baseDirection The literal's base direction, either "", "--ltr", or "--rtl".
+	 * @return A literal for the specified value and language attribute.
+	 */
+	Literal createLiteral(String label, String language, Literal.BaseDirection baseDirection);
+
+	/**
 	 * Creates a new literal with the supplied label and datatype.
 	 *
 	 * @param label    The literal's label, must not be <var>null</var>.

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -77,11 +77,12 @@ public abstract class AbstractLiteral implements Literal {
 	private static final long serialVersionUID = -1286527360744086451L;
 
 	static boolean reserved(IRI datatype) {
-		return CoreDatatype.RDF.LANGSTRING.getIri().equals(datatype);
+		return CoreDatatype.RDF.LANGSTRING.getIri().equals(datatype)
+				|| CoreDatatype.RDF.DIRLANGSTRING.getIri().equals(datatype);
 	}
 
 	static boolean reserved(CoreDatatype datatype) {
-		return CoreDatatype.RDF.LANGSTRING == datatype;
+		return CoreDatatype.RDF.LANGSTRING == datatype || CoreDatatype.RDF.DIRLANGSTRING == datatype;
 	}
 
 	/**
@@ -186,7 +187,7 @@ public abstract class AbstractLiteral implements Literal {
 
 		return getLanguage()
 
-				.map(language -> label + '@' + language)
+				.map(language -> label + '@' + language + getBaseDirection())
 
 				.orElseGet(() -> CoreDatatype.XSD.STRING == getCoreDatatype() ? label
 						: label + "^^<" + getDatatype().stringValue() + ">");
@@ -268,10 +269,16 @@ public abstract class AbstractLiteral implements Literal {
 
 		private final String label;
 		private final String language;
+		private final BaseDirection baseDirection;
 
 		TaggedLiteral(String label, String language) {
+			this(label, language, BaseDirection.NONE);
+		}
+
+		TaggedLiteral(String label, String language, BaseDirection baseDirection) {
 			this.label = label;
 			this.language = language;
+			this.baseDirection = baseDirection;
 		}
 
 		@Override
@@ -285,13 +292,19 @@ public abstract class AbstractLiteral implements Literal {
 		}
 
 		@Override
+		public BaseDirection getBaseDirection() {
+			return baseDirection;
+		}
+
+		@Override
 		public IRI getDatatype() {
-			return CoreDatatype.RDF.LANGSTRING.getIri();
+			return baseDirection == BaseDirection.NONE ? CoreDatatype.RDF.LANGSTRING.getIri()
+					: CoreDatatype.RDF.DIRLANGSTRING.getIri();
 		}
 
 		@Override
 		public CoreDatatype.RDF getCoreDatatype() {
-			return CoreDatatype.RDF.LANGSTRING;
+			return baseDirection == BaseDirection.NONE ? CoreDatatype.RDF.LANGSTRING : CoreDatatype.RDF.DIRLANGSTRING;
 		}
 	}
 

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
@@ -146,15 +146,21 @@ public abstract class AbstractValueFactory implements ValueFactory {
 
 	@Override
 	public Literal createLiteral(String label, String language) {
+		return createLiteral(label, language, Literal.BaseDirection.NONE);
+	}
+
+	@Override
+	public Literal createLiteral(String label, String language, Literal.BaseDirection baseDirection) {
 
 		Objects.requireNonNull(label, "null label");
 		Objects.requireNonNull(language, "null language");
+		Objects.requireNonNull(baseDirection, "null baseDirection");
 
 		if (language.isEmpty()) {
 			throw new IllegalArgumentException("empty language tag");
 		}
 
-		return new TaggedLiteral(label, language);
+		return new TaggedLiteral(label, language, baseDirection);
 	}
 
 	@Override

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
@@ -283,7 +283,9 @@ public interface CoreDatatype {
 	enum RDF implements CoreDatatype {
 
 		HTML(iri("HTML")),
+		JSON(iri("JSON")),
 		XMLLITERAL(iri("XMLLiteral")),
+		DIRLANGSTRING(iri("dirLangString")),
 		LANGSTRING(iri("langString"));
 
 		public static final String NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/ValueFactoryTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/ValueFactoryTest.java
@@ -71,6 +71,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -535,6 +536,18 @@ public abstract class ValueFactoryTest {
 		assertThat(literal.getLabel()).isEqualTo(string);
 		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DATETIME);
 
+	}
+
+	@Test
+	public void testCreateDirLangLiteral() {
+		final Literal literal = factory().createLiteral("label", "he", Literal.BaseDirection.RTL);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.getLabel()).isEqualTo("label");
+		assertThat(literal.getLanguage()).contains("he");
+		assertThat(literal.getBaseDirection()).isEqualTo(Literal.BaseDirection.RTL);
+		assertThat(literal.getBaseDirection().toString()).isEqualTo("--rtl");
+		assertThat(literal.getDatatype()).isEqualTo(CoreDatatype.RDF.DIRLANGSTRING.getIri());
 	}
 
 }

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/AbstractLiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/AbstractLiteralTest.java
@@ -11,11 +11,14 @@
 
 package org.eclipse.rdf4j.model.base;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.LiteralTest;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.AbstractValueFactoryTest.GenericValueFactory;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link AbstractLiteral}.
@@ -38,6 +41,11 @@ public class AbstractLiteralTest extends LiteralTest {
 	}
 
 	@Override
+	protected Literal literal(String label, String language, Literal.BaseDirection dir) {
+		return factory.createLiteral(label, language, dir);
+	}
+
+	@Override
 	protected Literal literal(String label, IRI datatype) {
 		return factory.createLiteral(label, datatype);
 	}
@@ -51,5 +59,4 @@ public class AbstractLiteralTest extends LiteralTest {
 	protected IRI datatype(String iri) {
 		return factory.createIRI(iri);
 	}
-
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF.java
@@ -87,7 +87,13 @@ public class RDF {
 	/** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString */
 	public static final IRI LANGSTRING = CoreDatatype.RDF.LANGSTRING.getIri();
 
+	/** http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString */
+	public static final IRI DIRLANGSTRING = CoreDatatype.RDF.DIRLANGSTRING.getIri();
+
 	/** http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML */
 	public static final IRI HTML = CoreDatatype.RDF.HTML.getIri();
+
+	/** http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON */
+	public static final IRI JSON = CoreDatatype.RDF.JSON.getIri();
 
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleValueFactory.java
@@ -104,6 +104,11 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	}
 
 	@Override
+	public Literal createLiteral(String value, String language, Literal.BaseDirection baseDirection) {
+		return new SimpleLiteral(value, language, baseDirection);
+	}
+
+	@Override
 	public Literal createLiteral(boolean b) {
 		return b ? BooleanLiteral.TRUE : BooleanLiteral.FALSE;
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -134,10 +134,15 @@ public class ValidatingValueFactory implements ValueFactory {
 
 	@Override
 	public Literal createLiteral(String label, String language) {
+		return createLiteral(label, language, Literal.BaseDirection.NONE);
+	}
+
+	@Override
+	public Literal createLiteral(String label, String language, Literal.BaseDirection baseDirection) {
 		if (!Literals.isValidLanguageTag(language)) {
 			throw new IllegalArgumentException("Not a valid language tag: " + language);
 		}
-		return delegate.createLiteral(label, language);
+		return delegate.createLiteral(label, language, baseDirection);
 	}
 
 	@Override

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -473,7 +473,8 @@ public class Literals {
 	 * @return True if the literal has a language tag attached to it and false otherwise.
 	 */
 	public static boolean isLanguageLiteral(Literal literal) {
-		return literal.getCoreDatatype() == CoreDatatype.RDF.LANGSTRING;
+		return literal.getCoreDatatype() == CoreDatatype.RDF.LANGSTRING
+				|| literal.getCoreDatatype() == CoreDatatype.RDF.DIRLANGSTRING;
 	}
 
 	/**
@@ -495,7 +496,7 @@ public class Literals {
 		new Locale.Builder().setLanguageTag(languageTag);
 
 		// all subtags are case-insensitive
-		String normalizedTag = languageTag.toLowerCase();
+		final String normalizedTag = languageTag.toLowerCase();
 
 		String[] subtags = normalizedTag.split("-");
 		for (int i = 1; i < subtags.length; i++) {

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleLiteralTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleLiteralTest.java
@@ -31,6 +31,11 @@ public class SimpleLiteralTest extends LiteralTest {
 	}
 
 	@Override
+	protected Literal literal(String label, String language, Literal.BaseDirection dir) {
+		return new SimpleLiteral(label, language, dir);
+	}
+
+	@Override
 	protected Literal literal(String label, IRI datatype) {
 		return new SimpleLiteral(label, datatype);
 	}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/LanguageHandler.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/LanguageHandler.java
@@ -87,6 +87,28 @@ public interface LanguageHandler {
 			throws LiteralUtilException;
 
 	/**
+	 * Normalize both the language tag and the language if appropriate, and use the given value factory to generate a
+	 * literal matching the literal value and language tag.
+	 * <p>
+	 * This method must only be called after verifying that {@link #isRecognizedLanguage(String)} returns true for the
+	 * given language tag, and {@link #verifyLanguage(String, String)} also returns true for the given language and
+	 * literal value.
+	 *
+	 * @param literalValue Required literal value to use in the normalization process and to provide the value for the
+	 *                     resulting literal.
+	 * @param languageTag  The language tag which is to be normalized. This tag is available in normalized form from the
+	 *                     result using {@link Literal#getLanguage()}.
+	 * @param baseDir
+	 * @param valueFactory The {@link ValueFactory} to use to create the result literal.
+	 * @return A {@link Literal} containing the normalized literal value and language tag.
+	 * @throws LiteralUtilException If the language tag was not recognized or verified, or the literal value could not
+	 *                              be normalized due to an error.
+	 */
+	Literal normalizeLanguage(String literalValue, String languageTag, Literal.BaseDirection baseDir,
+			ValueFactory valueFactory)
+			throws LiteralUtilException;
+
+	/**
 	 * A unique key for this language handler to identify it in the LanguageHandlerRegistry.
 	 *
 	 * @return A unique string key.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesUtil.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesUtil.java
@@ -565,6 +565,7 @@ public class NTriplesUtil {
 			// Append the literal's language
 			appendable.append("@");
 			appendable.append(lit.getLanguage().get());
+			appendable.append(lit.getBaseDirection().toString());
 		} else {
 			// SES-1917 : In RDF-1.1, all literals have a type, and if they are not
 			// language literals we display the type for backwards compatibility

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
@@ -72,6 +72,11 @@ class RDFStarDecodingValueFactory implements ValueFactory {
 	}
 
 	@Override
+	public Literal createLiteral(String label, String language, Literal.BaseDirection baseDirection) {
+		return delegate.createLiteral(label, language, baseDirection);
+	}
+
+	@Override
 	public Literal createLiteral(String label, IRI datatype) {
 		return delegate.createLiteral(label, datatype);
 	}

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors, Aduna, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.StringReader;
+import java.util.Collection;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/*
+* Testing base class for Turtle, TriG, NTriples, and NQuads parsers
+ */
+public abstract class AbstractParserTest {
+	protected RDFParser parser;
+	protected ParseErrorCollector errorCollector = new ParseErrorCollector();
+	protected StatementCollector statementCollector = new StatementCollector();
+	protected TestParseLocationListener locationListener = new TestParseLocationListener();
+
+	@BeforeEach
+	public void setUp() {
+		parser = createRDFParser();
+		parser.setParseErrorListener(errorCollector);
+		parser.setRDFHandler(statementCollector);
+		parser.setParseLocationListener(locationListener);
+	}
+
+	protected void dirLangStringTestHelper(
+			final String data, final String expectedLang, final String expectedBaseDir, final boolean normalize,
+			final boolean shouldFail) {
+		parser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+		parser.getParserConfig().set(BasicParserSettings.NORMALIZE_LANGUAGE_TAGS, normalize);
+
+		try {
+			parser.parse(new StringReader(data));
+
+			if (shouldFail) {
+				fail("default config should result in fatal error / parse exception");
+			}
+
+			assertThat(errorCollector.getErrors()).isEmpty();
+
+			final Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertThat(stmts).hasSize(1);
+
+			final Statement stmt = stmts.iterator().next();
+
+			assertEquals(CoreDatatype.RDF.DIRLANGSTRING.getIri(), ((Literal) stmt.getObject()).getDatatype());
+			assertTrue(((Literal) stmt.getObject()).getLanguage().isPresent());
+			assertEquals(expectedLang, ((Literal) stmt.getObject()).getLanguage().get());
+			assertEquals(expectedBaseDir, ((Literal) stmt.getObject()).getBaseDirection().toString());
+		} catch (final Exception e) {
+			if (!shouldFail) {
+				fail("parse error on correct data: " + e.getMessage());
+			}
+		}
+	}
+
+	protected void dirLangStringNoLanguageTestHelper(String data) {
+		try {
+			parser.parse(new StringReader(data));
+
+			assertThat(errorCollector.getErrors()).isEmpty();
+
+			Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertThat(stmts).hasSize(1);
+
+			Statement stmt = stmts.iterator().next();
+
+			assertEquals(CoreDatatype.XSD.STRING.getIri(), ((Literal) stmt.getObject()).getDatatype());
+		} catch (Exception e) {
+			fail("parse error on correct data: " + e.getMessage());
+		}
+	}
+
+	protected abstract RDFParser createRDFParser();
+
+	protected static class TestParseLocationListener extends SimpleParseLocationListener {
+
+		public void assertListener(int row, int col) {
+			assertEquals(row, this.getLineNo(), "Unexpected last row");
+			assertEquals(col, this.getColumnNo(), "Unexpected last col");
+		}
+
+	}
+
+	@Test
+	public void dummy() {
+	}
+
+}

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -50,6 +51,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Models;
@@ -1937,5 +1939,22 @@ public abstract class RDFWriterTest {
 			assertTrue(actual.contains(subj, pred, obj), "Missing " + st);
 			assertEquals(actual.filter(subj, pred, obj).size(), actual.filter(subj, pred, obj).size());
 		}
+	}
+
+	// Helper method for testing dirLangString literals in supported formats (Turtle, NTriples, TriG, NQuads)
+	public void dirLangStringTest(RDFFormat format) throws Exception {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		String ns = "http://example.org/";
+		IRI uri1 = vf.createIRI(ns, "uri1");
+		IRI uri2 = vf.createIRI(ns, "uri2");
+		model.add(vf.createStatement(uri1, uri2, vf.createLiteral("hello", "en", Literal.BaseDirection.LTR)));
+		model.add(vf.createStatement(uri1, uri2, vf.createLiteral("שלום", "he", Literal.BaseDirection.RTL)));
+
+		StringWriter stringWriter = new StringWriter();
+		Rio.write(model, stringWriter, format);
+		String output = stringWriter.toString();
+
+		assertThat(output).contains("\"hello\"@en--ltr");
+		assertThat(output).contains("\"שלום\"@he--rtl");
 	}
 }

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFParserHelperTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFParserHelperTest.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.rio.helpers;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -122,6 +123,33 @@ public class RDFParserHelperTest {
 	 * .
 	 */
 	@Test
+	public final void testCreateLiteralLabelAndLanguageAndDirection() {
+		Literal literalLTR = RDFParserHelper.createLiteral(LABEL_TESTA, LANG_EN + "--ltr", null, parserConfig,
+				errListener,
+				valueFactory);
+		Literal literalRTL = RDFParserHelper.createLiteral(LABEL_TESTA, "ar--rtl", null, parserConfig, errListener,
+				valueFactory);
+
+		assertEquals(LABEL_TESTA, literalLTR.getLabel());
+		assertEquals(LANG_EN, literalLTR.getLanguage().orElse(null));
+		assertEquals(Literal.BaseDirection.LTR, literalLTR.getBaseDirection());
+		assertEquals(RDF.DIRLANGSTRING, literalLTR.getDatatype());
+
+		assertEquals(LABEL_TESTA, literalRTL.getLabel());
+		assertEquals("ar", literalRTL.getLanguage().orElse(null));
+		assertEquals(Literal.BaseDirection.RTL, literalRTL.getBaseDirection());
+		assertEquals(RDF.DIRLANGSTRING, literalRTL.getDatatype());
+
+		assertThrows(RDFParseException.class, () -> RDFParserHelper.createLiteral(LABEL_TESTA, "he--jsldkfjds", null,
+				parserConfig, errListener, valueFactory));
+	}
+
+	/**
+	 * Test method for
+	 * {@link org.eclipse.rdf4j.rio.helpers.RDFParserHelper#createLiteral(java.lang.String, java.lang.String, org.eclipse.rdf4j.model.URI, org.eclipse.rdf4j.rio.ParserConfig, org.eclipse.rdf4j.rio.ParseErrorListener, org.eclipse.rdf4j.model.ValueFactory)}
+	 * .
+	 */
+	@Test
 	public final void testCreateLiteralLabelAndDatatype() {
 		Literal literal = RDFParserHelper.createLiteral(LABEL_TESTA, null, XSD.STRING, parserConfig, errListener,
 				valueFactory);
@@ -172,9 +200,27 @@ public class RDFParserHelperTest {
 	}
 
 	@Test
+	public final void testCreateLiteralLabelNoLanguageWithRDFDirLangStringWithVerify() {
+		parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
+		assertTrue(parserConfig.get(BasicParserSettings.VERIFY_DATATYPE_VALUES));
+		assertThatThrownBy(() -> RDFParserHelper.createLiteral(LABEL_TESTA, null, RDF.DIRLANGSTRING, parserConfig,
+				errListener, valueFactory))
+				.isInstanceOf(RDFParseException.class);
+	}
+
+	@Test
 	public final void testCreateLiteralLabelNoLanguageWithRDFLangStringWithNoVerify() {
 		parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, false);
 		Literal literal = RDFParserHelper.createLiteral(LABEL_TESTA, null, RDF.LANGSTRING, parserConfig, errListener,
+				valueFactory);
+		assertFalse(literal.getLanguage().isPresent());
+		assertEquals(XSD.STRING, literal.getDatatype());
+	}
+
+	@Test
+	public final void testCreateLiteralLabelNoLanguageWithRDFDirLangStringWithNoVerify() {
+		parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, false);
+		Literal literal = RDFParserHelper.createLiteral(LABEL_TESTA, null, RDF.DIRLANGSTRING, parserConfig, errListener,
 				valueFactory);
 		assertFalse(literal.getLanguage().isPresent());
 		assertEquals(XSD.STRING, literal.getDatatype());

--- a/core/rio/datatypes/src/main/java/org/eclipse/rdf4j/rio/datatypes/RDFDatatypeHandler.java
+++ b/core/rio/datatypes/src/main/java/org/eclipse/rdf4j/rio/datatypes/RDFDatatypeHandler.java
@@ -37,8 +37,10 @@ public class RDFDatatypeHandler implements DatatypeHandler {
 		}
 
 		return org.eclipse.rdf4j.model.vocabulary.RDF.LANGSTRING.equals(datatypeUri)
+				|| org.eclipse.rdf4j.model.vocabulary.RDF.DIRLANGSTRING.equals(datatypeUri)
 				|| org.eclipse.rdf4j.model.vocabulary.RDF.XMLLITERAL.equals(datatypeUri)
-				|| org.eclipse.rdf4j.model.vocabulary.RDF.HTML.equals(datatypeUri);
+				|| org.eclipse.rdf4j.model.vocabulary.RDF.HTML.equals(datatypeUri)
+				|| org.eclipse.rdf4j.model.vocabulary.RDF.JSON.equals(datatypeUri);
 	}
 
 	@Override

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
@@ -65,11 +65,19 @@ public class BCP47LanguageHandler implements LanguageHandler {
 	@Override
 	public Literal normalizeLanguage(String literalValue, String languageTag, ValueFactory valueFactory)
 			throws LiteralUtilException {
+		return normalizeLanguage(literalValue, languageTag, Literal.BaseDirection.NONE, valueFactory);
+	}
+
+	@Override
+	public Literal normalizeLanguage(String literalValue, String languageTag, Literal.BaseDirection baseDir,
+			ValueFactory valueFactory)
+			throws LiteralUtilException {
 		Objects.requireNonNull(languageTag, "Language tag cannot be null");
 		Objects.requireNonNull(literalValue, "Literal value cannot be null");
 
 		try {
-			return valueFactory.createLiteral(literalValue, Literals.normalizeLanguageTag(languageTag));
+			return valueFactory.createLiteral(literalValue,
+					Literals.normalizeLanguageTag(languageTag), baseDir);
 		} catch (IllformedLocaleException e) {
 			throw new LiteralUtilException("Could not normalize BCP47 language tag", e);
 		}

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/RFC3066LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/RFC3066LanguageHandler.java
@@ -67,11 +67,18 @@ public class RFC3066LanguageHandler implements LanguageHandler {
 	@Override
 	public Literal normalizeLanguage(String literalValue, String languageTag, ValueFactory valueFactory)
 			throws LiteralUtilException {
+		return normalizeLanguage(literalValue, languageTag, Literal.BaseDirection.NONE, valueFactory);
+	}
+
+	@Override
+	public Literal normalizeLanguage(String literalValue, String languageTag, Literal.BaseDirection baseDir,
+			ValueFactory valueFactory)
+			throws LiteralUtilException {
 		Objects.requireNonNull(languageTag, "Language tag cannot be null");
 		Objects.requireNonNull(literalValue, "Literal value cannot be null");
 
 		if (isRecognizedLanguage(languageTag)) {
-			return valueFactory.createLiteral(literalValue, languageTag.toLowerCase().intern());
+			return valueFactory.createLiteral(literalValue, languageTag.toLowerCase().intern(), baseDir);
 		}
 
 		throw new LiteralUtilException("Could not normalize RFC3066 language tag");

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
@@ -30,23 +30,20 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.AbstractParserTest;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
-import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
-import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for the N-Quads parser that uses the tests that are available
  * <a href="http://www.w3.org/2013/N-QuadsTests/">online</a>.
  */
-public abstract class AbstractNQuadsParserUnitTest {
+public abstract class AbstractNQuadsParserUnitTest extends AbstractParserTest {
 
 	/*-----------*
 	 * Constants *
@@ -60,33 +57,16 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 	private static final String NTRIPLES_TEST_FILE = "/testcases/ntriples/test.nt";
 
-	private RDFParser parser;
-
-	private TestRDFHandler rdfHandler;
-
-	@BeforeEach
-	public void setUp() {
-		parser = createRDFParser();
-		rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(this.rdfHandler);
-	}
-
-	@AfterEach
-	public void tearDown() {
-		parser = null;
-	}
-
 	/*---------*
 	 * Methods *
 	 *---------*/
 
 	public void testNQuadsFile() throws Exception {
-		RDFParser nquadsParser = createRDFParser();
-		nquadsParser.setRDFHandler(new AbstractRDFHandler() {
+		parser.setRDFHandler(new AbstractRDFHandler() {
 		});
 
 		try (InputStream in = AbstractNQuadsParserUnitTest.class.getResourceAsStream(NQUADS_TEST_FILE)) {
-			nquadsParser.parse(in, NQUADS_TEST_URL);
+			parser.parse(in, NQUADS_TEST_URL);
 		} catch (RDFParseException e) {
 			fail("NQuadsParser failed to parse N-Quads test document: " + e.getMessage());
 		}
@@ -96,12 +76,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 	 * The N-Quads parser must be able to parse the N-Triples test file without error.
 	 */
 	public void testNTriplesFile() throws Exception {
-		RDFParser nquadsParser = createRDFParser();
-		nquadsParser.setRDFHandler(new AbstractRDFHandler() {
+		parser.setRDFHandler(new AbstractRDFHandler() {
 		});
 
 		try (InputStream in = AbstractNQuadsParserUnitTest.class.getResourceAsStream(NTRIPLES_TEST_FILE)) {
-			nquadsParser.parse(in, NTRIPLES_TEST_URL);
+			parser.parse(in, NTRIPLES_TEST_URL);
 		} catch (RDFParseException e) {
 			fail("NQuadsParser failed to parse N-Triples test document: " + e.getMessage());
 		}
@@ -186,10 +165,8 @@ public abstract class AbstractNQuadsParserUnitTest {
 	public void testParseEmptyLinesAndComments() throws RDFHandlerException, IOException, RDFParseException {
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"  \n\n\n# This is a comment\n\n#this is another comment.".getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		assertEquals(rdfHandler.getStatements().size(), 0);
+		assertEquals(0, statementCollector.getStatements().size());
 	}
 
 	/**
@@ -200,11 +177,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"<http://www.v/dat/4b> <http://www.w3.org/20/ica#dtend> <http://sin/value/2> <http://sin.siteserv.org/def/> ."
 						.getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		assertEquals(1, rdfHandler.getStatements().size());
-		final Statement statement = rdfHandler.getStatements().iterator().next();
+		assertEquals(1, statementCollector.getStatements().size());
+		final Statement statement = statementCollector.getStatements().iterator().next();
 		assertEquals("http://www.v/dat/4b", statement.getSubject().stringValue());
 		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
 		assertTrue(statement.getObject() instanceof IRI);
@@ -220,11 +195,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"_:a123456768 <http://www.w3.org/20/ica#dtend> <http://sin/value/2> <http://sin.siteserv.org/def/>."
 						.getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		assertThat(rdfHandler.getStatements()).hasSize(1);
-		final Statement statement = rdfHandler.getStatements().iterator().next();
+		assertThat(statementCollector.getStatements()).hasSize(1);
+		final Statement statement = statementCollector.getStatements().iterator().next();
 		assertTrue(statement.getSubject() instanceof BNode);
 		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
 		assertTrue(statement.getObject() instanceof IRI);
@@ -240,11 +213,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"_:a123456768 <http://www.w3.org/20/ica#dtend> \"2010-05-02\" <http://sin.siteserv.org/def/>."
 						.getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		assertThat(rdfHandler.getStatements()).hasSize(1);
-		final Statement statement = rdfHandler.getStatements().iterator().next();
+		assertThat(statementCollector.getStatements()).hasSize(1);
+		final Statement statement = statementCollector.getStatements().iterator().next();
 		assertTrue(statement.getSubject() instanceof BNode);
 		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
 		assertTrue(statement.getObject() instanceof Literal);
@@ -260,10 +231,8 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"<http://www.v/dat/4b2-21> <http://www.w3.org/20/ica#dtend> \"2010-05-02\"@en <http://sin.siteserv.org/def/>."
 						.getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		final Statement statement = rdfHandler.getStatements().iterator().next();
+		final Statement statement = statementCollector.getStatements().iterator().next();
 		assertEquals("http://www.v/dat/4b2-21", statement.getSubject().stringValue());
 		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
 		assertTrue(statement.getObject() instanceof Literal);
@@ -283,10 +252,8 @@ public abstract class AbstractNQuadsParserUnitTest {
 				("<http://www.v/dat/4b2-21> " + "<http://www.w3.org/20/ica#dtend> "
 						+ "\"2010\"^^<http://www.w3.org/2001/XMLSchema#integer> " + "<http://sin.siteserv.org/def/>.")
 						.getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		final Statement statement = rdfHandler.getStatements().iterator().next();
+		final Statement statement = statementCollector.getStatements().iterator().next();
 		assertEquals("http://www.v/dat/4b2-21", statement.getSubject().stringValue());
 		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
 		assertTrue(statement.getObject() instanceof Literal);
@@ -307,8 +274,6 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				("<http://www.v/dat/4b2-21> " + "<http://www.w3.org/20/ica#dtend> " + "\"2010\"^^xsd:integer "
 						+ "<http://sin.siteserv.org/def/>.").getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		try {
 			parser.parse(bais, "http://test.base.uri");
 			fail("Expected exception when passing in a datatype using an N3 style prefix");
@@ -324,19 +289,14 @@ public abstract class AbstractNQuadsParserUnitTest {
 	 */
 	@Test
 	public void testLiteralEscapeManagement1() throws RDFHandlerException, IOException, RDFParseException {
-		TestParseLocationListener parseLocationListener = new TestParseLocationListener();
-		TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setParseLocationListener(parseLocationListener);
-		parser.setRDFHandler(rdfHandler);
-
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"<http://a> <http://b> \"\\\\\" <http://c> .".getBytes());
 		parser.parse(bais, "http://base-uri");
 
-		rdfHandler.assertHandler(1);
-		// parseLocationListener.assertListener(1, 40);
+		assertEquals(1, statementCollector.getStatements().size());
+		// locationListener.assertListener(1, 40);
 		// FIXME: Enable column numbers when parser supports them
-		parseLocationListener.assertListener(1, 1);
+		locationListener.assertListener(1, 1);
 	}
 
 	/**
@@ -344,17 +304,12 @@ public abstract class AbstractNQuadsParserUnitTest {
 	 */
 	@Test
 	public void testLiteralEscapeManagement2() throws RDFHandlerException, IOException, RDFParseException {
-		TestParseLocationListener parseLocationListener = new TestParseLocationListener();
-		TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setParseLocationListener(parseLocationListener);
-		parser.setRDFHandler(rdfHandler);
-
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"<http://a> <http://b> \"Line text 1\\nLine text 2\" <http://c> .".getBytes());
 		parser.parse(bais, "http://base-uri");
 
-		rdfHandler.assertHandler(1);
-		final Value object = rdfHandler.getStatements().iterator().next().getObject();
+		assertEquals(1, statementCollector.getStatements().size());
+		final Value object = statementCollector.getStatements().iterator().next().getObject();
 		assertTrue(object instanceof Literal);
 		final String literalContent = ((Literal) object).getLabel();
 		assertEquals("Line text 1\nLine text 2", literalContent);
@@ -365,18 +320,13 @@ public abstract class AbstractNQuadsParserUnitTest {
 	 */
 	@Test
 	public void testURIDecodingManagement() throws RDFHandlerException, IOException, RDFParseException {
-		TestParseLocationListener parseLocationListener = new TestParseLocationListener();
-		TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setParseLocationListener(parseLocationListener);
-		parser.setRDFHandler(rdfHandler);
-
 		final ByteArrayInputStream bais = new ByteArrayInputStream(
 				"<http://s/\\u306F\\u3080> <http://p/\\u306F\\u3080> <http://o/\\u306F\\u3080> <http://g/\\u306F\\u3080> ."
 						.getBytes());
 		parser.parse(bais, "http://base-uri");
 
-		rdfHandler.assertHandler(1);
-		final Statement statement = rdfHandler.getStatements().iterator().next();
+		assertEquals(1, statementCollector.getStatements().size());
+		final Statement statement = statementCollector.getStatements().iterator().next();
 
 		final Resource subject = statement.getSubject();
 		assertTrue(subject instanceof IRI);
@@ -401,16 +351,14 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 	@Test
 	public void testUnicodeLiteralDecoding() throws RDFHandlerException, IOException, RDFParseException {
-		TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		final String INPUT_LITERAL_PLAIN = "[は]";
 		final String INPUT_LITERAL_ENCODED = "[\\u306F]";
 		final String INPUT_STRING = String.format("<http://a> <http://b> \"%s\" <http://c> .", INPUT_LITERAL_ENCODED);
 		final ByteArrayInputStream bais = new ByteArrayInputStream(INPUT_STRING.getBytes());
 		parser.parse(bais, "http://base-uri");
 
-		rdfHandler.assertHandler(1);
-		final Literal obj = (Literal) rdfHandler.getStatements().iterator().next().getObject();
+		assertEquals(1, statementCollector.getStatements().size());
+		final Literal obj = (Literal) statementCollector.getStatements().iterator().next().getObject();
 		assertEquals(INPUT_LITERAL_PLAIN, obj.getLabel());
 	}
 
@@ -452,17 +400,12 @@ public abstract class AbstractNQuadsParserUnitTest {
 	 */
 	@Test
 	public void testParserWithAllCases() throws IOException, RDFParseException, RDFHandlerException {
-		TestParseLocationListener parseLocationListerner = new TestParseLocationListener();
-		// SpecificTestRDFHandler rdfHandler = new SpecificTestRDFHandler();
-		parser.setParseLocationListener(parseLocationListerner);
-		parser.setRDFHandler(rdfHandler);
-
 		BufferedReader br = new BufferedReader(new InputStreamReader(
 				AbstractNQuadsParserUnitTest.class.getResourceAsStream("/testcases/nquads/test1.nq")));
 		parser.parse(br, "http://test.base.uri");
 
-		rdfHandler.assertHandler(6);
-		parseLocationListerner.assertListener(8, 1);
+		assertEquals(6, statementCollector.getStatements().size());
+		locationListener.assertListener(8, 1);
 	}
 
 	/**
@@ -470,16 +413,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 	 */
 	@Test
 	public void testParserWithRealData() throws IOException, RDFParseException, RDFHandlerException {
-		TestParseLocationListener parseLocationListener = new TestParseLocationListener();
-		TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setParseLocationListener(parseLocationListener);
-		parser.setRDFHandler(rdfHandler);
-
 		parser.parse(AbstractNQuadsParserUnitTest.class.getResourceAsStream("/testcases/nquads/test2.nq"),
 				"http://test.base.uri");
 
-		rdfHandler.assertHandler(400);
-		parseLocationListener.assertListener(400, 1);
+		assertEquals(400, statementCollector.getStatements().size());
+		locationListener.assertListener(400, 1);
 	}
 
 	@Test
@@ -566,15 +504,13 @@ public abstract class AbstractNQuadsParserUnitTest {
 						// with
 						// error.
 						"<http://s1> <http://p1> <http://o1> <http://g1> .\n").getBytes());
-		final TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 
 		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, false);
 		parser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 
 		parser.parse(bais, "http://base-uri");
-		rdfHandler.assertHandler(2);
-		final Collection<Statement> statements = rdfHandler.getStatements();
+		assertEquals(2, statementCollector.getStatements().size());
+		final Collection<Statement> statements = statementCollector.getStatements();
 		int i = 0;
 		for (Statement nextStatement : statements) {
 			assertEquals("http://s" + i, nextStatement.getSubject().stringValue());
@@ -587,8 +523,6 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 	private void verifyStatementWithInvalidDatatype(boolean useDatatypeVerification)
 			throws RDFHandlerException, IOException, RDFParseException {
-		TestRDFHandler rdfHandler = new TestRDFHandler();
-		parser.setRDFHandler(rdfHandler);
 		parser.getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, useDatatypeVerification);
 		parser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, useDatatypeVerification);
 		if (!useDatatypeVerification) {
@@ -603,41 +537,70 @@ public abstract class AbstractNQuadsParserUnitTest {
 						+ "<http://it.wikipedia.org/wiki/Camillo_Benso,_conte_di_Cavour#absolute-line=20> .")
 						.getBytes());
 		parser.parse(bais, "http://base-uri");
-		rdfHandler.assertHandler(1);
+		assertEquals(1, statementCollector.getStatements().size());
 	}
 
-	private class TestParseLocationListener extends SimpleParseLocationListener {
-
-		private void assertListener(int row, int col) {
-			assertEquals(row, this.getLineNo(), "Unexpected last row");
-			assertEquals(col, this.getColumnNo(), "Unexpected last col");
-		}
-
+	@Test
+	public void testDirLangStringRTLNoContext() {
+		final String data = "<http://example/a> <http://example/b> \"שלום\"@he--rtl";
+		dirLangStringTest(data, false, "he", Literal.RTL_SUFFIX, false, false);
 	}
 
-	private class TestRDFHandler extends StatementCollector {
+	@Test
+	public void testDirLangStringRTLWithContext() {
+		final String data = "<http://example/a> <http://example/b> \"שלום\"@he--rtl";
+		dirLangStringTest(data, true, "he", Literal.RTL_SUFFIX, false, false);
+	}
 
-		private boolean started = false;
+	@Test
+	public void testDirLangStringLTRWithNormalizationNoContext() {
+		String data = "<http://example/a> <http://example/b> \"Hello\"@en--ltr";
+		dirLangStringTest(data, false, "en", Literal.LTR_SUFFIX, true, false);
+	}
 
-		private boolean ended = false;
+	@Test
+	public void testDirLangStringLTRWithNormalizationWithContext() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--ltr";
+		dirLangStringTest(data, true, "en", Literal.LTR_SUFFIX, true, false);
+	}
 
-		@Override
-		public void startRDF() throws RDFHandlerException {
-			super.startRDF();
-			started = true;
-		}
+	@Test
+	public void testBadDirLangStringNoContext() {
+		final String data = "<http://example/a> <http://example/b> \"hello\"@en--unk";
+		dirLangStringTest(data, false, "", "", true, true);
+	}
 
-		@Override
-		public void endRDF() throws RDFHandlerException {
-			super.endRDF();
-			ended = true;
-		}
+	@Test
+	public void testBadDirLangStringWithContext() {
+		final String data = "<http://example/a> <http://example/b> \"hello\"@en--unk";
+		dirLangStringTest(data, true, "", "", true, true);
+	}
 
-		public void assertHandler(int expected) {
-			assertTrue(started, "Never started.");
-			assertTrue(ended, "Never ended.");
-			assertEquals(expected, getStatements().size(), "Unexpected number of statements.");
-		}
+	@Test
+	public void testBadCapitalizationDirLangStringNoContext() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--LTR";
+		dirLangStringTest(data, false, "", "", true, true);
+	}
+
+	@Test
+	public void testBadCapitalizationDirLangStringWithContext() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--LTR";
+		dirLangStringTest(data, true, "", "", true, true);
+	}
+
+	@Test
+	public void testDirLangStringNoLanguage() throws IOException {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString> .";
+		dirLangStringNoLanguageTestHelper(data);
+	}
+
+	private void dirLangStringTest(
+			final String triple, final boolean withContext, final String expectedLang, final String expectedDir,
+			final boolean normalize,
+			final boolean shouldCauseException) {
+		final String data = triple + (withContext ? " <http://www.example.org/>" : "") + " .";
+
+		dirLangStringTestHelper(data, expectedLang, expectedDir, normalize, shouldCauseException);
 	}
 
 	@Test

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsWriterTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsWriterTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
@@ -153,6 +154,11 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 		assertEquals(1, lines.length, "Unexpected number of lines.");
 		assertTrue(lines[0].startsWith(
 				"<http://test.example.org/test/subject/1> <http://other.example.com/test/predicate/1> \"test literal\"^^<http://www.w3.org/2001/XMLSchema#string> _:"));
+	}
+
+	@Test
+	public void testDirLangString() throws Exception {
+		dirLangStringTest(RDFFormat.NQUADS);
 	}
 
 	@Override

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -24,17 +25,19 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
 
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.rio.AbstractParserTest;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
-import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,20 +45,26 @@ import org.junit.jupiter.api.Test;
  *
  * @author Peter Ansell
  */
-public abstract class AbstractNTriplesParserUnitTest {
+public abstract class AbstractNTriplesParserUnitTest extends AbstractParserTest {
 
 	private static final String NTRIPLES_TEST_URL = "http://www.w3.org/2000/10/rdf-tests/rdfcore/ntriples/test.nt";
 
 	private static final String NTRIPLES_TEST_FILE = "/testcases/ntriples/test.nt";
 
+	private Model model;
+
+	@BeforeEach
+	@Override
+	public void setUp() {
+		model = new LinkedHashModel();
+		statementCollector = new StatementCollector(model);
+		super.setUp();
+	}
+
 	@Test
 	public void testNTriplesFile() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-
 		try (InputStream in = this.getClass().getResourceAsStream(NTRIPLES_TEST_FILE)) {
-			ntriplesParser.parse(in, NTRIPLES_TEST_URL);
+			parser.parse(in, NTRIPLES_TEST_URL);
 		} catch (RDFParseException e) {
 			fail("Failed to parse N-Triples test document: " + e.getMessage());
 		}
@@ -70,15 +79,11 @@ public abstract class AbstractNTriplesParserUnitTest {
 	public void testExceptionHandlingWithDefaultSettings() throws Exception {
 		String data = "invalid nt";
 
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-
 		try {
-			ntriplesParser.parse(new StringReader(data), NTRIPLES_TEST_URL);
+			parser.parse(new StringReader(data), NTRIPLES_TEST_URL);
 			fail("expected RDFParseException due to invalid data");
 		} catch (RDFParseException expected) {
-			assertEquals(expected.getLineNumber(), 1);
+			assertEquals(1, expected.getLineNumber());
 		}
 	}
 
@@ -86,17 +91,13 @@ public abstract class AbstractNTriplesParserUnitTest {
 	public void testExceptionHandlingWithStopAtFirstError() throws Exception {
 		String data = "invalid nt";
 
-		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, Boolean.TRUE);
-
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
+		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, Boolean.TRUE);
 
 		try {
-			ntriplesParser.parse(new StringReader(data), NTRIPLES_TEST_URL);
+			parser.parse(new StringReader(data), NTRIPLES_TEST_URL);
 			fail("expected RDFParseException due to invalid data");
 		} catch (RDFParseException expected) {
-			assertEquals(expected.getLineNumber(), 1);
+			assertEquals(1, expected.getLineNumber());
 		}
 	}
 
@@ -104,13 +105,9 @@ public abstract class AbstractNTriplesParserUnitTest {
 	public void testExceptionHandlingWithoutStopAtFirstError() throws Exception {
 		String data = "invalid nt";
 
-		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
+		parser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-
-		ntriplesParser.parse(new StringReader(data), NTRIPLES_TEST_URL);
+		parser.parse(new StringReader(data), NTRIPLES_TEST_URL);
 
 		assertEquals(0, model.size());
 		assertEquals(0, model.subjects().size());
@@ -122,13 +119,9 @@ public abstract class AbstractNTriplesParserUnitTest {
 	public void testExceptionHandlingWithoutStopAtFirstError2() throws Exception {
 		String data = "invalid nt";
 
-		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, false);
+		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, false);
 
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-
-		ntriplesParser.parse(new StringReader(data), NTRIPLES_TEST_URL);
+		parser.parse(new StringReader(data), NTRIPLES_TEST_URL);
 
 		assertEquals(0, model.size());
 		assertEquals(0, model.subjects().size());
@@ -138,10 +131,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEscapes() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:subject> <urn:test:predicate> \" \\t \\b \\n \\r \\f \\\" \\' \\\\ \" . "),
 				"http://example/");
 		assertEquals(1, model.size());
@@ -150,10 +140,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentNoSpace() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .#endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
@@ -162,10 +149,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentWithSpaceBefore() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . #endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
@@ -174,10 +158,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentWithSpaceAfter() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .# endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
@@ -186,10 +167,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentWithSpaceBoth() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . # endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
@@ -198,10 +176,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentsNoSpace() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader(
+		parser.parse(new StringReader(
 				"<urn:test:subject> <urn:test:predicate> <urn:test:object> .#endoflinecomment\n<urn:test:subject> <urn:test:predicate> <urn:test:secondobject> . # endoflinecomment\n"),
 				"http://example/");
 		assertEquals(2, model.size());
@@ -209,10 +184,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentsWithSpaceBefore() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader(
+		parser.parse(new StringReader(
 				"<urn:test:subject> <urn:test:predicate> <urn:test:object> . #endoflinecomment\n<urn:test:subject> <urn:test:predicate> <urn:test:secondobject> . # endoflinecomment\n"),
 				"http://example/");
 		assertEquals(2, model.size());
@@ -220,10 +192,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentsWithSpaceAfter() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader(
+		parser.parse(new StringReader(
 				"<urn:test:subject> <urn:test:predicate> <urn:test:object> .# endoflinecomment\n<urn:test:subject> <urn:test:predicate> <urn:test:secondobject> . # endoflinecomment\n"),
 				"http://example/");
 		assertEquals(2, model.size());
@@ -231,10 +200,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineCommentsWithSpaceBoth() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader(
+		parser.parse(new StringReader(
 				"<urn:test:subject> <urn:test:predicate> <urn:test:object> . # endoflinecomment\n<urn:test:subject> <urn:test:predicate> <urn:test:secondobject> . # endoflinecomment\n"),
 				"http://example/");
 		assertEquals(2, model.size());
@@ -242,10 +208,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineEmptyCommentNoSpace() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .#\n"),
+		parser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .#\n"),
 				"http://example/");
 		assertEquals(1, model.size());
 		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
@@ -253,10 +216,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineEmptyCommentWithSpaceBefore() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . #\n"),
+		parser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . #\n"),
 				"http://example/");
 		assertEquals(1, model.size());
 		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
@@ -264,10 +224,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineEmptyCommentWithSpaceAfter() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .# \n"),
+		parser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .# \n"),
 				"http://example/");
 		assertEquals(1, model.size());
 		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
@@ -275,10 +232,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testEndOfLineEmptyCommentWithSpaceBoth() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . # \n"),
+		parser.parse(new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . # \n"),
 				"http://example/");
 		assertEquals(1, model.size());
 		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
@@ -286,10 +240,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testBlankNodeIdentifiersRDF11() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("_:123 <urn:test:predicate> _:456 ."), "http://example/");
+		parser.parse(new StringReader("_:123 <urn:test:predicate> _:456 ."), "http://example/");
 		assertEquals(1, model.size());
 	}
 
@@ -300,14 +251,10 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testUriWithSpaceShouldFailToParse() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-
 		String nt = "<http://example/ space> <http://example/p> <http://example/o> .";
 
 		try {
-			ntriplesParser.parse(new StringReader(nt), NTRIPLES_TEST_URL);
+			parser.parse(new StringReader(nt), NTRIPLES_TEST_URL);
 			fail("Should have failed to parse invalid N-Triples uri with space");
 		} catch (RDFParseException ignored) {
 		}
@@ -320,14 +267,10 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testUriWithEscapeCharactersShouldFailToParse() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-
 		String nt = "<http://example/\\n> <http://example/p> <http://example/o> .";
 
 		try {
-			ntriplesParser.parse(new StringReader(nt), NTRIPLES_TEST_URL);
+			parser.parse(new StringReader(nt), NTRIPLES_TEST_URL);
 			fail("Should have failed to parse invalid N-Triples uri with space");
 		} catch (RDFParseException ignored) {
 		}
@@ -341,10 +284,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 	@Test
 	public void testBlankNodeIdentifiersWithUnderScore() throws Exception {
 		// The characters _ and [0-9] may appear anywhere in a blank node label.
-		RDFParser ntriplesParser = new NTriplesParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("_:123_ <urn:test:predicate> _:_456 ."), NTRIPLES_TEST_URL);
+		parser.parse(new StringReader("_:123_ <urn:test:predicate> _:_456 ."), NTRIPLES_TEST_URL);
 
 		assertEquals(1, model.size());
 		assertEquals(1, model.subjects().size());
@@ -355,10 +295,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 	@Test
 	public void testBlankNodeIdentifiersWithDot() throws Exception {
 		// The character . may appear anywhere except the first or last character.
-		RDFParser ntriplesParser = new NTriplesParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		ntriplesParser.parse(new StringReader("_:1.23 <urn:test:predicate> _:45.6 ."), NTRIPLES_TEST_URL);
+		parser.parse(new StringReader("_:1.23 <urn:test:predicate> _:45.6 ."), NTRIPLES_TEST_URL);
 
 		assertEquals(1, model.size());
 		assertEquals(1, model.subjects().size());
@@ -369,11 +306,8 @@ public abstract class AbstractNTriplesParserUnitTest {
 	@Test
 	public void testBlankNodeIdentifiersWithDotAsFirstCahracter() {
 		// The character . may appear anywhere except the first or last character.
-		RDFParser ntriplesParser = new NTriplesParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
 		try {
-			ntriplesParser.parse(new StringReader("_:123 <urn:test:predicate> _:.456 ."), NTRIPLES_TEST_URL);
+			parser.parse(new StringReader("_:123 <urn:test:predicate> _:.456 ."), NTRIPLES_TEST_URL);
 			fail("Should have failed to parse invalid N-Triples bnode with '.' at the begining of the bnode label");
 		} catch (Exception e) {
 		}
@@ -387,11 +321,8 @@ public abstract class AbstractNTriplesParserUnitTest {
 	@Test
 	public void testBlankNodeIdentifiersWithDotAsLastCahracter() {
 		// The character . may appear anywhere except the first or last character.
-		RDFParser ntriplesParser = new NTriplesParser();
-		Model model = new LinkedHashModel();
-		ntriplesParser.setRDFHandler(new StatementCollector(model));
 		assertThrows(RDFParseException.class,
-				() -> ntriplesParser.parse(new StringReader("_:123 <urn:test:predicate> _:456. ."), NTRIPLES_TEST_URL));
+				() -> parser.parse(new StringReader("_:123 <urn:test:predicate> _:456. ."), NTRIPLES_TEST_URL));
 		assertEquals(0, model.size());
 		assertEquals(0, model.subjects().size());
 		assertEquals(0, model.predicates().size());
@@ -412,13 +343,12 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 		for (int i = 0; i < charactersList.size(); i++) {
 			Character character = charactersList.get(i);
-			RDFParser ntriplesParser = new NTriplesParser();
 			Model model = new LinkedHashModel();
-			ntriplesParser.setRDFHandler(new StatementCollector(model));
+			parser.setRDFHandler(new StatementCollector(model));
 
 			String triple = "<urn:test:subject> <urn:test:predicate> _:1" + character + " . ";
 			try {
-				ntriplesParser.parse(new StringReader(triple), NTRIPLES_TEST_URL);
+				parser.parse(new StringReader(triple), NTRIPLES_TEST_URL);
 			} catch (Exception e) {
 				fail(" Failed to parse triple : " + triple + " containing character '" + character + "' at index " + i
 						+ " in charactersList");
@@ -448,12 +378,11 @@ public abstract class AbstractNTriplesParserUnitTest {
 		charactersList.add('\u203F');
 
 		for (Character character : charactersList) {
-			RDFParser ntriplesParser = new NTriplesParser();
 			Model model = new LinkedHashModel();
-			ntriplesParser.setRDFHandler(new StatementCollector(model));
+			parser.setRDFHandler(new StatementCollector(model));
 
 			assertThrows(RDFParseException.class, () -> {
-				ntriplesParser.parse(
+				parser.parse(
 						new StringReader("<urn:test:subject> <urn:test:predicate> _:" + character + "1 . "),
 						NTRIPLES_TEST_URL);
 			});
@@ -479,12 +408,11 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testHandleComment() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
 		Model model = new LinkedHashModel();
 		String commentStr = "some comment in it's own line";
 		CommentCollector cc = new CommentCollector(model);
-		ntriplesParser.setRDFHandler(cc);
-		ntriplesParser.parse(
+		parser.setRDFHandler(cc);
+		parser.parse(
 				new StringReader("<s:1> <p:1> <o:1> .\n#" + commentStr + "\n<s:2> <p:2> <o:2> ."),
 				"http://example/");
 		assertEquals(2, model.size());
@@ -494,16 +422,13 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testLinenumberDatatypeValidation() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
-		ntriplesParser.getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
-		ParseErrorCollector collector = new ParseErrorCollector();
-		ntriplesParser.setParseErrorListener(collector);
+		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
+		parser.getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:o> <urn:test:p> \"invalid\"^^<" + XSD.DATETIME.stringValue() + "> ."),
 				NTRIPLES_TEST_URL);
-		List<String> errors = collector.getErrors();
+		List<String> errors = errorCollector.getErrors();
 
 		assertEquals(1, errors.size());
 		assertTrue(errors.get(0).contains("(1, 32)"), "Unknown line number");
@@ -511,20 +436,59 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testLinenumberLanguagetagValidation() throws Exception {
-		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().addNonFatalError(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES);
-		ntriplesParser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
-		ntriplesParser.getParserConfig().set(BasicParserSettings.VERIFY_LANGUAGE_TAGS, true);
-		ParseErrorCollector collector = new ParseErrorCollector();
-		ntriplesParser.setParseErrorListener(collector);
+		parser.getParserConfig().addNonFatalError(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES);
+		parser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+		parser.getParserConfig().set(BasicParserSettings.VERIFY_LANGUAGE_TAGS, true);
 
-		ntriplesParser.parse(
+		parser.parse(
 				new StringReader("<urn:test:o> <urn:test:p> \"hello\"@inv+alid ."),
 				NTRIPLES_TEST_URL);
-		List<String> errors = collector.getErrors();
+		List<String> errors = errorCollector.getErrors();
 
 		assertEquals(1, errors.size());
 		assertTrue(errors.get(0).contains("(1, 32)"), "Unknown line number");
+	}
+
+	@Test
+	public void testDirLangStringLTR() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--ltr .";
+		dirLangStringTestHelper(data, "en", Literal.LTR_SUFFIX, false, false);
+	}
+
+	@Test
+	public void testDirLangStringRTL() {
+		final String data = "<http://example/a> <http://example/b> \"שלום\"@he--rtl .";
+		dirLangStringTestHelper(data, "he", Literal.RTL_SUFFIX, false, false);
+	}
+
+	@Test
+	public void testDirLangStringLTRWithNormalization() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--ltr .";
+		dirLangStringTestHelper(data, "en", Literal.LTR_SUFFIX, true, false);
+	}
+
+	@Test
+	public void testDirLangStringRTLWithNormalization() {
+		final String data = "<http://example/a> <http://example/b> \"שלום\"@HE--rtl .";
+		dirLangStringTestHelper(data, "he", Literal.RTL_SUFFIX, true, false);
+	}
+
+	@Test
+	public void testBadDirLangString() {
+		final String data = "<http://example/a> <http://example/b> \"hello\"@en--unk .";
+		dirLangStringTestHelper(data, "", "", true, true);
+	}
+
+	@Test
+	public void testBadCapitalizationDirLangString() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--LTR .";
+		dirLangStringTestHelper(data, "", "", true, true);
+	}
+
+	@Test
+	public void testDirLangStringNoLanguage() throws IOException {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString> .";
+		dirLangStringNoLanguageTestHelper(data);
 	}
 
 	protected abstract RDFParser createRDFParser();

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesWriterTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesWriterTest.java
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.ntriples;
 
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParserFactory;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesWriterSettings;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeen Broekstra
@@ -34,4 +36,8 @@ public abstract class AbstractNTriplesWriterTest extends RDFWriterTest {
 		};
 	}
 
+	@Test
+	public void testDirLangString() throws Exception {
+		dirLangStringTest(RDFFormat.NTRIPLES);
+	}
 }

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterTest.java
@@ -10,6 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.ntriples;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.junit.jupiter.api.Test;
+
 /**
  * JUnit test for the RDF/JSON parser.
  *

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/AbstractTriGWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/AbstractTriGWriterTest.java
@@ -10,12 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trig;
 
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParserFactory;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeen Broesktra
@@ -35,5 +37,10 @@ public abstract class AbstractTriGWriterTest extends RDFWriterTest {
 				BasicWriterSettings.BASE_DIRECTIVE,
 				TurtleWriterSettings.ABBREVIATE_NUMBERS
 		};
+	}
+
+	@Test
+	public void testDirLangString() throws Exception {
+		dirLangStringTest(RDFFormat.TRIG);
 	}
 }

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -16,22 +16,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Models;
-import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.AbstractParserTest;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
-import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,34 +41,21 @@ import org.junit.jupiter.api.Timeout;
  * @author Peter Ansell
  */
 @Timeout(value = 10, unit = TimeUnit.MINUTES)
-public class TriGParserCustomTest {
-	private ValueFactory vf;
+public class TriGParserCustomTest extends AbstractParserTest {
 
-	private ParserConfig settingsNoVerifyLangTag;
+	private Model model;
 
-	private ParseErrorCollector errors;
-
-	private RDFParser parser;
-
-	private StatementCollector statementCollector;
-
-	/**
-	 */
 	@BeforeEach
 	public void setUp() {
-		vf = SimpleValueFactory.getInstance();
-		settingsNoVerifyLangTag = new ParserConfig();
-		settingsNoVerifyLangTag.set(BasicParserSettings.VERIFY_LANGUAGE_TAGS, false);
-		errors = new ParseErrorCollector();
-		parser = Rio.createParser(RDFFormat.TRIG);
-		statementCollector = new StatementCollector(new LinkedHashModel());
-		parser.setRDFHandler(statementCollector);
+		model = new LinkedHashModel();
+		statementCollector = new StatementCollector(model);
+		super.setUp();
 	}
 
 	@Test
 	public void testSPARQLGraphKeyword() throws Exception {
-		Model model = Rio.parse(new StringReader("GRAPH <urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
+		String data = "GRAPH <urn:a> { [] <http://www.example.net/test> \"Foo\" }";
+		parser.parse(new StringReader(data));
 
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
@@ -82,8 +67,8 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testGraph() throws Exception {
-		Model model = Rio.parse(new StringReader("<urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
+		String data = "<urn:a> { [] <http://www.example.net/test> \"Foo\" }";
+		parser.parse(new StringReader(data));
 
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
@@ -95,9 +80,8 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testGraphLocalNameGraph() throws Exception {
-		Model model = Rio.parse(
-				new StringReader("@prefix graph: <urn:> .\n graph:a { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
+		String data = "@prefix graph: <urn:> .\n graph:a { [] <http://www.example.net/test> \"Foo\" }";
+		parser.parse(new StringReader(data));
 
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
@@ -109,9 +93,8 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testGraphLocalNameIntegerGraph() throws Exception {
-		Model model = Rio.parse(
-				new StringReader("@prefix graph: <urn:> .\n graph:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
+		String data = "@prefix graph: <urn:> .\n graph:1 { [] <http://www.example.net/test> \"Foo\" }";
+		parser.parse(new StringReader(data));
 
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
@@ -123,9 +106,8 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testGraphLocalNameNotGraph() throws Exception {
-		Model model = Rio.parse(
-				new StringReader("@prefix ex: <urn:> .\n ex:a { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
+		String data = "@prefix ex: <urn:> .\n ex:a { [] <http://www.example.net/test> \"Foo\" }";
+		parser.parse(new StringReader(data));
 
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
@@ -137,9 +119,8 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testGraphLocalNameIntegerNotGraph() throws Exception {
-		Model model = Rio.parse(
-				new StringReader("@prefix ex: <urn:> .\n ex:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
+		String data = "@prefix ex: <urn:> .\n ex:1 { [] <http://www.example.net/test> \"Foo\" }";
+		parser.parse(new StringReader(data));
 
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
@@ -151,40 +132,38 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testTrailingSemicolon() throws Exception {
-		Rio.parse(new StringReader("{<http://example/s> <http://example/p> <http://example/o> ;}"), "", RDFFormat.TRIG);
+		parser.parse(new StringReader("{<http://example/s> <http://example/p> <http://example/o> ;}"), "");
 	}
 
 	@Test
 	public void testAnonymousGraph1() throws Exception {
-		Rio.parse(new StringReader("PREFIX : <http://example/>\n GRAPH [] { :s :p :o }"), "", RDFFormat.TRIG);
+		parser.parse(new StringReader("PREFIX : <http://example/>\n GRAPH [] { :s :p :o }"), "");
 	}
 
 	@Test
 	public void testAnonymousGraph2() throws Exception {
-		Rio.parse(new StringReader("PREFIX : <http://example/>\n [] { :s :p :o }"), "", RDFFormat.TRIG);
+		parser.parse(new StringReader("PREFIX : <http://example/>\n [] { :s :p :o }"), "");
 	}
 
 	@Test
 	public void testTurtle() throws Exception {
-		Rio.parse(new StringReader("<urn:a> <urn:b> <urn:c>"), "", RDFFormat.TRIG);
+		parser.parse(new StringReader("<urn:a> <urn:b> <urn:c>"), "");
 	}
 
 	@Test
 	public void testMinimalWhitespace() throws Exception {
-		Rio.parse(this.getClass().getResourceAsStream("/testcases/trig/trig-syntax-minimal-whitespace-01.trig"), "",
-				RDFFormat.TRIG);
+		parser.parse(this.getClass().getResourceAsStream("/testcases/trig/trig-syntax-minimal-whitespace-01.trig"), "");
 	}
 
 	@Test
 	public void testMinimalWhitespaceLine12() throws Exception {
-		Rio.parse(new StringReader("@prefix : <http://example/c/> . {_:s:p :o ._:s:p\"Alice\". _:s:p _:o .}"), "",
-				RDFFormat.TRIG);
+		parser.parse(new StringReader("@prefix : <http://example/c/> . {_:s:p :o ._:s:p\"Alice\". _:s:p _:o .}"), "");
 	}
 
 	@Test
 	public void testBadPname02() throws Exception {
 		try {
-			Rio.parse(new StringReader("@prefix : <http://example/> . {:a%2 :p :o .}"), "", RDFFormat.TRIG);
+			parser.parse(new StringReader("@prefix : <http://example/> . {:a%2 :p :o .}"), "");
 			fail("Did not receive expected exception");
 		} catch (RDFParseException e) {
 
@@ -198,35 +177,103 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testParseTruePrefix() throws Exception {
-		Rio.parse(new StringReader("@prefix true: <http://example/c/> . {true:s true:p true:o .}"), "", RDFFormat.TRIG);
+		parser.parse(new StringReader("@prefix true: <http://example/c/> . {true:s true:p true:o .}"), "");
 	}
 
 	@Test
 	public void testParseTrig_booleanLiteral() throws Exception {
 		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> true.\n" + "}";
-		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
-		assertEquals(1, m.size());
+		parser.parse(new StringReader(trig), "http://ex/");
+		assertEquals(1, model.size());
 	}
 
 	@Test
 	public void testParseTrig_booleanLiteral_space() throws Exception {
 		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> true .\n" + "}";
-		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
-		assertEquals(1, m.size());
+		parser.parse(new StringReader(trig), "http://ex/");
+		assertEquals(1, model.size());
 	}
 
 	@Test
 	public void testParseTrig_intLiteral() throws Exception {
 		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> 1.\n" + "}";
-		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
-		assertEquals(1, Models.objectLiteral(m).get().intValue());
+		parser.parse(new StringReader(trig), "http://ex/");
+		assertEquals(1, Models.objectLiteral(model).get().intValue());
 	}
 
 	@Test
 	public void testParseTrig_doubleLiteral() throws Exception {
 		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> 1.2.\n" + "}";
-		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
-		assertEquals(1.2d, Models.objectLiteral(m).get().doubleValue(), 0.01);
+		parser.parse(new StringReader(trig), "http://ex/");
+		assertEquals(1.2d, Models.objectLiteral(model).get().doubleValue(), 0.01);
 	}
 
+	@Test
+	public void testDirLangStringRTLNoContext() {
+		String data = "<http://example/a> <http://example/b> \"שלום\"@he--rtl";
+		dirLangStringTest(data, false, "he", Literal.RTL_SUFFIX, false, false);
+	}
+
+	@Test
+	public void testDirLangStringRTLWithContext() {
+		String data = "<http://example/a> <http://example/b> \"שלום\"@he--rtl";
+		dirLangStringTest(data, true, "he", Literal.RTL_SUFFIX, false, false);
+	}
+
+	@Test
+	public void testDirLangStringLTRWithNormalizationNoContext() {
+		String data = "<http://example/a> <http://example/b> \"Hello\"@en--ltr";
+		dirLangStringTest(data, false, "en", Literal.LTR_SUFFIX, true, false);
+	}
+
+	@Test
+	public void testDirLangStringLTRWithNormalizationWithContext() {
+		String data = "<http://example/a> <http://example/b> \"Hello\"@en--ltr";
+		dirLangStringTest(data, true, "en", Literal.LTR_SUFFIX, true, false);
+	}
+
+	@Test
+	public void testBadDirLangStringNoContext() {
+		String data = "<http://example/a> <http://example/b> \"hello\"@en--unk";
+		dirLangStringTest(data, false, "", "", true, true);
+	}
+
+	@Test
+	public void testBadDirLangStringWithContext() {
+		String data = "<http://example/a> <http://example/b> \"hello\"@en--unk";
+		dirLangStringTest(data, true, "", "", true, true);
+	}
+
+	@Test
+	public void testBadCapitalizationDirLangStringNoContext() {
+		String data = "<http://example/a> <http://example/b> \"Hello\"@en--LTR";
+		dirLangStringTest(data, false, "", "", true, true);
+	}
+
+	@Test
+	public void testBadCapitalizationDirLangStringWithContext() {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"@en--LTR";
+		dirLangStringTest(data, true, "", "", true, true);
+	}
+
+	@Test
+	public void testDirLangStringNoLanguage() throws IOException {
+		final String data = "<http://example/a> <http://example/b> \"Hello\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString> .";
+		dirLangStringNoLanguageTestHelper(data);
+	}
+
+	private void dirLangStringTest(
+			final String triple, final boolean withContext, final String expectedLang, final String expectedBaseDir,
+			final boolean normalize,
+			final boolean shouldCauseException) {
+		final String data = (withContext ? "<http://www.example.org/> { " : "") + triple + " ."
+				+ (withContext ? " }" : "");
+
+		dirLangStringTestHelper(data, expectedLang, expectedBaseDir, normalize, shouldCauseException);
+	}
+
+	@Override
+	public RDFParser createRDFParser() {
+		return new TriGParser();
+	}
 }

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -682,6 +682,7 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 			// Append the literal's language
 			writer.write("@");
 			writer.write(lit.getLanguage().get());
+			writer.write(lit.getBaseDirection().toString());
 		} else if (!xsdStringToPlainLiteral || !XSD.STRING.equals(datatype)) {
 			// Append the literal's datatype (possibly written as an abbreviated
 			// URI)

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/AbstractTurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/AbstractTurtleWriterTest.java
@@ -15,12 +15,10 @@ import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.eclipse.rdf4j.rio.RDFParserFactory;
-import org.eclipse.rdf4j.rio.RDFWriterFactory;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeen Broekstra
@@ -48,5 +46,10 @@ public abstract class AbstractTurtleWriterTest extends RDFWriterTest {
 		m.add(Values.iri("http://www.example.com/int"), RDF.VALUE, Values.literal("-2", XSD.INTEGER));
 		m.add(Values.iri("http://www.example.com/decimal"), RDF.VALUE, Values.literal("55.66", XSD.DECIMAL));
 		return m;
+	}
+
+	@Test
+	public void dirLangStringTest() throws Exception {
+		dirLangStringTest(RDFFormat.TURTLE);
 	}
 }

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
@@ -18,6 +18,7 @@ import java.io.StringWriter;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -753,5 +754,25 @@ public class TurtleWriterTest extends AbstractTurtleWriterTest {
 		assertTrue(result.contains("\"1234567.89\"^^<http://www.w3.org/2001/XMLSchema#double>"));
 		assertTrue(result.contains("\"-2\"^^<http://www.w3.org/2001/XMLSchema#integer>"));
 		assertTrue(result.contains("\"55.66\"^^<http://www.w3.org/2001/XMLSchema#decimal>"));
+	}
+
+	@Test
+	public void testAdditionalDatatypes() {
+		Model model = new DynamicModelFactory().createEmptyModel();
+		String ns = "http://www.example.com/";
+		model.add(vf.createIRI(ns, "subject"), vf.createIRI(ns, "predicate"),
+				vf.createLiteral("object1", CoreDatatype.RDF.JSON));
+		model.add(vf.createIRI(ns, "subject"), vf.createIRI(ns, "predicate"),
+				vf.createLiteral("object2", CoreDatatype.RDF.HTML));
+		model.add(vf.createIRI(ns, "subject"), vf.createIRI(ns, "predicate"),
+				vf.createLiteral("object3", CoreDatatype.RDF.XMLLITERAL));
+
+		StringWriter stringWriter = new StringWriter();
+		Rio.write(model, stringWriter, RDFFormat.TURTLE);
+
+		assertThat(stringWriter.toString()).contains("\"object1\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON>");
+		assertThat(stringWriter.toString()).contains("\"object2\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML>");
+		assertThat(stringWriter.toString())
+				.contains("\"object3\"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral>");
 	}
 }

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchDataStructure.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchDataStructure.java
@@ -243,6 +243,9 @@ class ElasticsearchDataStructure implements DataStructureInterface {
 				if (((Literal) object).getLanguage().isPresent()) {
 					boolQueryBuilder
 							.must(QueryBuilders.termQuery("object_Lang", ((Literal) object).getLanguage().get()));
+					boolQueryBuilder
+							.must(QueryBuilders.termQuery("object_LangDir",
+									((Literal) object).getBaseDirection().toString()));
 				}
 			}
 		}
@@ -450,7 +453,7 @@ class ElasticsearchDataStructure implements DataStructureInterface {
 					((Literal) statement.getObject()).getDatatype().stringValue());
 			if (((Literal) statement.getObject()).getLanguage().isPresent()) {
 				jsonMap.put("object_Lang", ((Literal) statement.getObject()).getLanguage().get());
-
+				jsonMap.put("object_LangDir", ((Literal) statement.getObject()).getBaseDirection().toString());
 			}
 		}
 		return jsonMap;
@@ -673,8 +676,8 @@ class ElasticsearchDataStructure implements DataStructureInterface {
 			objectRes = vf.createBNode(objectString);
 		} else {
 			if (sourceAsMap.containsKey("object_Lang")) {
-				objectRes = vf.createLiteral(objectString, (String) sourceAsMap.get("object_Lang"));
-
+				objectRes = vf.createLiteral(objectString, (String) sourceAsMap.get("object_Lang"),
+						Literal.BaseDirection.fromString((String) sourceAsMap.get("object_LangDir")));
 			} else {
 				objectRes = vf.createLiteral(objectString,
 						vf.createIRI((String) sourceAsMap.get("object_Datatype")));

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -1531,6 +1531,11 @@ class ValueStore extends AbstractValueFactory {
 		return new LmdbLiteral(revision, value, language);
 	}
 
+	@Override
+	public LmdbLiteral createLiteral(String value, String language, Literal.BaseDirection baseDirection) {
+		return new LmdbLiteral(revision, value, language, baseDirection);
+	}
+
 	/*----------------------------------------------------------------------*
 	 * Methods for converting model objects to LmdbStore-specific objects *
 	 *----------------------------------------------------------------------*/

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.sail.lmdb.model;
 
 import java.io.ObjectStreamException;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -39,6 +40,8 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	 * The literal's language tag.
 	 */
 	private String language;
+
+	private BaseDirection baseDirection;
 
 	/**
 	 * The literal's datatype.
@@ -79,10 +82,25 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	}
 
 	public LmdbLiteral(ValueStoreRevision revision, String label, String lang, long internalID) {
+		this(revision, label, lang, BaseDirection.NONE, internalID);
+	}
+
+	public LmdbLiteral(ValueStoreRevision revision, String label, String lang, BaseDirection baseDirection) {
+		this(revision, label, lang, baseDirection, UNKNOWN_ID);
+	}
+
+	public LmdbLiteral(ValueStoreRevision revision, String label, String language, BaseDirection baseDirection,
+			long internalID) {
+		Objects.requireNonNull(language, "null language");
+		Objects.requireNonNull(baseDirection, "null baseDirection");
 		this.label = label;
-		this.language = lang;
-		coreDatatype = CoreDatatype.RDF.LANGSTRING;
-		datatype = CoreDatatype.RDF.LANGSTRING.getIri();
+		this.language = language;
+		this.baseDirection = baseDirection;
+		if (baseDirection != BaseDirection.NONE) {
+			setDatatype(CoreDatatype.RDF.DIRLANGSTRING);
+		} else {
+			setDatatype(CoreDatatype.RDF.LANGSTRING);
+		}
 		setInternalID(internalID, revision);
 		this.initialized = true;
 	}
@@ -186,6 +204,11 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	public Optional<String> getLanguage() {
 		init();
 		return Optional.ofNullable(language);
+	}
+
+	@Override
+	public BaseDirection getBaseDirection() {
+		return baseDirection;
 	}
 
 	public void setLanguage(String language) {

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemLiteral.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemLiteral.java
@@ -65,6 +65,19 @@ public class MemLiteral extends SimpleLiteral implements MemValue {
 	}
 
 	/**
+	 * Creates a new Literal which will get the supplied label, language code, and base direction.
+	 *
+	 * @param creator       The object that is creating this MemLiteral.
+	 * @param label         The label for this literal.
+	 * @param lang          The language code of the supplied label.
+	 * @param baseDirection The base direction as a string ("", "--ltr", "--rtl").
+	 */
+	public MemLiteral(Object creator, String label, String lang, BaseDirection baseDirection) {
+		super(label, lang, baseDirection);
+		this.creator = creator;
+	}
+
+	/**
 	 * Creates a new Literal which will get the supplied label and datatype.
 	 *
 	 * @param creator  The object that is creating this MemLiteral.

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
@@ -302,7 +302,7 @@ public class MemValueFactory extends AbstractValueFactory {
 			IRI datatype = coreDatatype != CoreDatatype.NONE ? coreDatatype.getIri() : literal.getDatatype();
 
 			if (Literals.isLanguageLiteral(literal)) {
-				return new MemLiteral(this, label, literal.getLanguage().get());
+				return new MemLiteral(this, label, literal.getLanguage().get(), literal.getBaseDirection());
 			} else {
 				try {
 					if (coreDatatype.isXSDDatatype()) {
@@ -404,6 +404,11 @@ public class MemValueFactory extends AbstractValueFactory {
 	@Override
 	public Literal createLiteral(String value, String language) {
 		return getOrCreateMemLiteral(super.createLiteral(value, language));
+	}
+
+	@Override
+	public Literal createLiteral(String value, String language, Literal.BaseDirection baseDirection) {
+		return getOrCreateMemLiteral(super.createLiteral(value, language, baseDirection));
 	}
 
 	@Override

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactoryTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactoryTest.java
@@ -13,6 +13,8 @@ package org.eclipse.rdf4j.sail.memory.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.junit.jupiter.api.Test;
 
 public class MemValueFactoryTest {
@@ -28,4 +30,14 @@ public class MemValueFactoryTest {
 		assertThat(factory.createIRI(namespace, localName)).isInstanceOf(IRI.class);
 	}
 
+	@Test
+	public void testCreateDirLangLiteral() {
+		final Literal literal = new MemValueFactory().createLiteral("label", "he", Literal.BaseDirection.RTL);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.getLabel()).isEqualTo("label");
+		assertThat(literal.getLanguage()).contains("he");
+		assertThat(literal.getBaseDirection().toString()).isEqualTo("--rtl");
+		assertThat(literal.getDatatype()).isEqualTo(CoreDatatype.RDF.DIRLANGSTRING.getIri());
+	}
 }

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStore.java
@@ -743,6 +743,11 @@ public class ValueStore extends SimpleValueFactory {
 	}
 
 	@Override
+	public NativeLiteral createLiteral(String value, String language, Literal.BaseDirection baseDirection) {
+		return new NativeLiteral(revision, value, language, baseDirection);
+	}
+
+	@Override
 	public NativeLiteral createLiteral(String value, IRI datatype) {
 		return new NativeLiteral(revision, value, datatype);
 	}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/NativeLiteral.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/NativeLiteral.java
@@ -58,6 +58,16 @@ public class NativeLiteral extends SimpleLiteral implements NativeValue {
 		setInternalID(internalID, revision);
 	}
 
+	public NativeLiteral(ValueStoreRevision revision, String label, String lang, BaseDirection baseDirection) {
+		this(revision, label, lang, baseDirection, UNKNOWN_ID);
+	}
+
+	public NativeLiteral(ValueStoreRevision revision, String label, String lang, BaseDirection baseDirection,
+			int internalID) {
+		super(label, lang, baseDirection);
+		setInternalID(internalID, revision);
+	}
+
 	public NativeLiteral(ValueStoreRevision revision, String label, IRI datatype) {
 		this(revision, label, datatype, UNKNOWN_ID);
 	}

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFStoreTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFStoreTest.java
@@ -323,6 +323,24 @@ public abstract class RDFStoreTest {
 		testValueRoundTrip(subj, pred, obj);
 	}
 
+	@Test
+	public void testDirLangStringRoundTrip() {
+		IRI subj = vf.createIRI(EXAMPLE_NS + PICASSO);
+		IRI pred = vf.createIRI(EXAMPLE_NS + PAINTS);
+		Literal obj = vf.createLiteral("guernica", "es", Literal.BaseDirection.LTR);
+
+		testValueRoundTrip(subj, pred, obj);
+	}
+
+	@Test
+	public void testJSONLiteralRoundTrip() {
+		IRI subj = vf.createIRI(EXAMPLE_NS + PICASSO);
+		IRI pred = vf.createIRI(EXAMPLE_NS + PAINTS);
+		Literal obj = vf.createLiteral("{ \"name\" : \"guernica\", \"dateCreated\": 1937 }", RDF.JSON);
+
+		testValueRoundTrip(subj, pred, obj);
+	}
+
 	private void testValueRoundTrip(Resource subj, IRI pred, Value obj) {
 		con.begin();
 		con.addStatement(subj, pred, obj);


### PR DESCRIPTION
GH-5327 added support for RDF 1.2 literals - JSON datatype and directed language strings - in Turtle Parser, NTriples Parser, NQuads Parser, and TriG Parser

Updated constructors and datatype getters in Literal and inheritors

Refactored testing code for parsers to share common functionality in AbstractParserTest

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

